### PR TITLE
3.3.1

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shortcut-assistant-backend",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "The backend service powering the Shortcut Assistant browser extension.",
   "main": "dist/src/server.js",
   "scripts": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,7 @@ import express, { Application, json } from 'express'
 import authMiddleware from '@sb/middleware/auth-headers'
 import apiRouter from '@sb/routes/api'
 import labelsRouter from '@sb/routes/labels'
-import usersRouter from '@sb/routes/users'
+import noAuthUsersRouter from '@sb/routes/users'
 
 
 const app: Application = express()
@@ -19,10 +19,10 @@ app.use(cors({
   allowedHeaders: ['Content-Type', 'Authorization']
 }))
 app.use(json())
-// This is deprecated
-app.use('/api', apiRouter)
+
+app.use('/api', apiRouter) // This route is deprecated
+app.use('/users', noAuthUsersRouter)
 app.use(authMiddleware)
-app.use('/users', usersRouter)
 app.use('/labels', labelsRouter)
 
 Sentry.setupExpressErrorHandler(app)

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,6 +25,8 @@ app.use('/users', noAuthUsersRouter)
 app.use(authMiddleware)
 app.use('/labels', labelsRouter)
 
-Sentry.setupExpressErrorHandler(app)
+if (process.env.NODE_ENV !== 'development') {
+  Sentry.setupExpressErrorHandler(app)
+}
 
 export default app

--- a/src/controllers/users/utils/register.ts
+++ b/src/controllers/users/utils/register.ts
@@ -15,15 +15,15 @@ const ZodUser = z.object({
 
 
 async function registerUserFromGoogle(request: Request): Promise<User | ZodError> {
-  const userInfo = request.body
+  const requestBody: { shortcutApiToken: string, googleAuthToken: string } = request.body
 
-  const userResult = ZodUser.safeParse(userInfo)
-  const authenticatedPayload = await googleAuthenticate(request.headers.authorization!)
+  const userResult = ZodUser.safeParse(requestBody)
+  const authenticatedPayload = await googleAuthenticate(requestBody.googleAuthToken)
   if (!userResult.success) {
     return userResult.error
   }
 
-  const shortcutApiToken: string = userResult.data.shortcutApiToken
+  const shortcutApiToken: string = requestBody.shortcutApiToken
   const encryptedToken = encrypt(shortcutApiToken)
 
   const newUser: UserInterface = {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -3,6 +3,7 @@ import { Router } from 'express'
 import processAnalysis from '@sb/controllers/ai/analyze/analysis'
 
 
+// The API route is deprecated
 const router = Router()
 router.post('/openai', processAnalysis)
 

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -4,7 +4,9 @@ import authenticate from '@sb/controllers/users/authenticate'
 import register from '@sb/controllers/users/register'
 
 
-const usersRouter = Router()
-usersRouter.post('/register', register)
-usersRouter.post('/authenticate', authenticate)
-export default usersRouter
+// NOTE that authentication middleware is applied *after* the usersRouter in src/app.ts
+// This means that any routes defined in usersRouter will not be protected by the authMiddleware
+const noAuthUsersRouter = Router()
+noAuthUsersRouter.post('/register', register)
+noAuthUsersRouter.post('/authenticate', authenticate)
+export default noAuthUsersRouter

--- a/tests/controllers/users/utils/register.test.ts
+++ b/tests/controllers/users/utils/register.test.ts
@@ -48,9 +48,7 @@ describe('registerUserFromGoogle', () => {
   it('should save the user to the database if userInfo is valid', async () => {
     const mockSave = database.manager.save as jest.Mock
     mockSave.mockResolvedValue(mockUser)
-    const validUserInfo = {
-      name: 'John Doe',
-      email: 'john.doe@example.com', // invalid email
+    const requestBody = {
       shortcutApiToken: 'sometoken',
       googleAuthToken: 'google123',
     }
@@ -67,9 +65,11 @@ describe('registerUserFromGoogle', () => {
       name: 'John Doe' } as GoogleUserInfo
     mockGoogleAuthenticate.mockResolvedValue(googleUser)
 
-    const request = { body: validUserInfo, headers: { authorization: '213' } } as unknown as Request
+    const request = { body: requestBody, headers: { authorization: requestBody.shortcutApiToken } } as unknown as Request
     const result = await registerUserFromGoogle(request)
     expect(result).toEqual(mockUser)
     expect(database.manager.save).toHaveBeenCalledWith(User, expectedSaveData)
+    expect(encrypt).toHaveBeenCalledWith('sometoken')
+    expect(googleAuthenticate).toHaveBeenCalledWith('google123')
   })
 })

--- a/tests/routes/api.test.ts
+++ b/tests/routes/api.test.ts
@@ -14,7 +14,7 @@ jest.mock('@sb/controllers/ai/analyze/analysis', () => jest.fn())
 
 describe('router', () => {
   it('should add a post route to /openai', () => {
-    require('@sb/routes/api') // Import the module here after the mock
+    require('@sb/routes/api')
 
     expect(mockRouter.post).toHaveBeenCalledWith('/openai', processAnalysis)
   })

--- a/tests/routes/users.test.ts
+++ b/tests/routes/users.test.ts
@@ -1,0 +1,24 @@
+import authenticate from '@sb/controllers/users/authenticate'
+import register from '@sb/controllers/users/register'
+
+
+const mockRouter = {
+  post: jest.fn(),
+}
+
+jest.mock('express', () => ({
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  Router: () => mockRouter,
+}))
+
+jest.mock('@sb/controllers/users/register', () => jest.fn())
+jest.mock('@sb/controllers/users/authenticate', () => jest.fn())
+
+describe('router', () => {
+  it('should add a post route to /openai', () => {
+    require('@sb/routes/users')
+
+    expect(mockRouter.post).toHaveBeenCalledWith('/register', register)
+    expect(mockRouter.post).toHaveBeenCalledWith('/authenticate', authenticate)
+  })
+})


### PR DESCRIPTION
## What's Changed
- Use Google Auth token from request body during authorization for Google check
- Configure Dependabot 
- Allow Sentry to be initialized for testing purposes